### PR TITLE
Register extension version (requires GK v0.9.0)

### DIFF
--- a/geokey_export/__init__.py
+++ b/geokey_export/__init__.py
@@ -8,5 +8,6 @@ register(
     'geokey_export',
     'Export',
     display_admin=True,
-    superuser=False
+    superuser=False,
+    version=__version__
 )


### PR DESCRIPTION
Pass extension version to GK upon registering.

*Note*: travis fails because this requires GK v0.9.0 which isn't released yet.